### PR TITLE
Make sure to include urdfdom_compatibility.h.

### DIFF
--- a/include/urdf_geometry_parser/urdf_geometry_parser.h
+++ b/include/urdf_geometry_parser/urdf_geometry_parser.h
@@ -37,6 +37,7 @@
 
 #include <ros/ros.h>
 
+#include <urdf/urdfdom_compatibility.h>
 #include <urdf_parser/urdf_parser.h>
 
 namespace urdf_geometry_parser {


### PR DESCRIPTION
This ensures that urdf_geometry_parser will build on all distros
(including older Debian Jessie).

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>