### PR TITLE
Cleanup CMakeLists.txt and package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,40 +1,52 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(urdf_geometry_parser)
 
-set(${PROJECT_NAME}_CATKIN_DEPS roscpp urdf tf2)
-
-find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS})
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS ${${PROJECT_NAME}_CATKIN_DEPS}
+# Load catkin and all dependencies required for this package
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  tf2
+  urdf
 )
+
+# Declare a catkin package
+catkin_package(
+  INCLUDE_DIRS
+    include
+  LIBRARIES
+    ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    roscpp
+    urdf
+)
+
 
 ###########
 ## Build ##
 ###########
 
-include_directories(
-  include ${catkin_INCLUDE_DIRS}
-)
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS})
 
-## Declare a C++ library
+# URDF geometry parser library
 add_library(${PROJECT_NAME}
-  src/${PROJECT_NAME}.cpp
+  include/urdf_geometry_parser/urdf_geometry_parser.h
+  src/urdf_geometry_parser.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
 
 #############
 ## Install ##
 #############
 
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(urdf_geometry_parser)
 
 # Load catkin and all dependencies required for this package

--- a/package.xml
+++ b/package.xml
@@ -1,23 +1,23 @@
-<?xml version="1.0"?>
 <package format="2">
   <name>urdf_geometry_parser</name>
   <version>0.0.3</version>
-  <description>Extract geometry value of a vehicle from urdf</description>
+  <description>Extract geometry value of a vehicle from urdf.</description>
 
   <maintainer email="vincent.rousseau@irstea.fr">Vincent Rousseau</maintainer>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
 
   <license>BSD</license>
 
+  <url type="website">http://ros.org/wiki/urdf_geometry_parser</url>
+  <url type="bugtracker">https://github.com/ros-controls/urdf_geometry_parser/issues</url>
+  <url type="repository">https://github.com/ros-controls/urdf_geometry_parser.git</url>
+
   <author email="vincent.rousseau@irstea.fr">Vincent Rousseau</author>
 
-  <url type="website">http://ros.org/wiki/urdf_geometry_parser</url>
-  <url type="repository">https://github.com/ros-controls/urdf_geometry_parser.git</url>
-  <url type="bugtracker">https://github.com/ros-controls/urdf_geometry_parser/issues</url>
-
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>roscpp</depend>
   <depend>urdf</depend>
-  <depend>tf2</depend>
 
+  <build_depend>tf2</build_depend>
 </package>


### PR DESCRIPTION
 - Bump CMake version to avoid CMP0048 warning
 - Change tf2 to build_depend
 - Change runtime install destination from `CATKIN_PACKAGE_BIN_DESTINATION` to `CATKIN_GLOBAL_BIN_DESTINATION`
 - Apply formatting from ros-controls/ros_control#404

This may conflict with #13, so depending on which gets merged first, I'll need to rebase the other. Not a big deal.