### PR TITLE
Remove tf2 dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(urdf_geometry_parser)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   roscpp
-  tf2
   urdf
 )
 

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,6 @@
   <depend>roscpp</depend>
   <depend>urdf</depend>
 
-  <build_depend>tf2</build_depend>
-
   <test_depend>rostest</test_depend>
   <test_depend>xacro</test_depend>
 </package>

--- a/src/urdf_geometry_parser.cpp
+++ b/src/urdf_geometry_parser.cpp
@@ -34,7 +34,7 @@
 
 #include <urdf_geometry_parser/urdf_geometry_parser.h>
 
-#include <tf2/LinearMath/Vector3.h>
+#include <cmath>
 
 namespace urdf_geometry_parser{
 
@@ -154,11 +154,9 @@ namespace urdf_geometry_parser{
     if(!getTransformVector(second_joint_name, base_link_, second_transform))
       return false;
 
-    tf2::Vector3 v1(first_transform.x, first_transform.y, 0.0),
-                 v2(second_transform.x, second_transform.y, 0.0);
-    distance = v1.distance(v2);
-    ROS_DEBUG_STREAM("first_transform : "<<first_transform.x<<","<<first_transform.y);
-    ROS_DEBUG_STREAM("distance "<<distance);
+    // Calculate the Euclidean distance using the Pythagorean formula
+    distance = std::sqrt(std::pow(first_transform.x - second_transform.x, 2)
+                         + std::pow(first_transform.y - second_transform.y, 2));
     return true;
   }
 


### PR DESCRIPTION
As @bmagyar mentioned in #10, `tf2` is barely used, and we can easily remove the dependency on it to keep things slightly lighter.